### PR TITLE
add in game currency symbol and formatted all prices to be locale

### DIFF
--- a/src/app/compendium/components/demon-stats.component.ts
+++ b/src/app/compendium/components/demon-stats.component.ts
@@ -23,7 +23,7 @@ import Translations from '../data/translations.json';
         </thead>
         <tbody>
           <tr>
-            <td *ngIf="price" [attr.rowSpan]="growths.length">{{ price }}</td>
+            <td *ngIf="price" [attr.rowSpan]="growths.length">{{ inGameCurrencySymbol + (price | number:'1.0-0') }}</td>
             <td *ngFor="let stat of stats">{{ stat }}</td>
             <td *ngIf="inherits" [attr.rowSpan]="growths.length"><div class="element-icon inherit-icon i{{ inherits }}">{{ inherits }}</div></td>
             <ng-content></ng-content>
@@ -45,5 +45,6 @@ export class DemonStatsComponent {
   @Input() inherits: number;
   @Input() price = 0;
   @Input() lang = 'en';
+  @Input() inGameCurrencySymbol: string;
   msgs = Translations.DemonStatsComponent;
 }

--- a/src/app/compendium/components/fusion-entry-table.component.ts
+++ b/src/app/compendium/components/fusion-entry-table.component.ts
@@ -18,7 +18,7 @@ import Translations from '../data/translations.json';
       </thead>
       <tbody>
         <tr *ngFor="let data of rowData">
-          <td>{{ data.price }}</td>
+          <td>{{ inGameCurrencySymbol + (data.price | number:'1.0-0') }}</td>
           <td>{{ data.race1 }}</td>
           <td>{{ data.lvl1 | lvlToNumber }}</td>
           <td><a routerLink="{{ baseUrl }}/{{ data.name1 }}">{{ data.name1 }}</a></td>
@@ -33,5 +33,6 @@ export class FusionEntryTableComponent {
   @Input() rowData: FusionEntry[];
   @Input() isFusion = false;
   @Input() lang = 'en';
+  @Input() inGameCurrencySymbol: string;
   msgs = Translations.FusionPairTableComponent;
 }

--- a/src/app/compendium/components/fusion-pair-table.component.ts
+++ b/src/app/compendium/components/fusion-pair-table.component.ts
@@ -9,7 +9,7 @@ import Translations from '../data/translations.json';
   selector: 'tr.app-fusion-pair-table-row',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <td class="price">{{ data.price }}</td>
+    <td class="price">{{ inGameCurrencySymbol+(data.price | number:'1.0-0') }}</td>
     <td>{{ data.race1 }}</td>
     <td>{{ data.lvl1 | lvlToNumber }}</td>
     <td><a routerLink="{{ leftBaseUrl }}/{{ data.name1 }}">{{ data.name1 }}</a></td>
@@ -22,6 +22,7 @@ export class FusionPairTableRowComponent {
   @Input() data: FusionPair;
   @Input() leftBaseUrl: string;
   @Input() rightBaseUrl: string;
+  @Input() inGameCurrencySymbol: string;
 }
 
 @Component({
@@ -89,7 +90,8 @@ export class FusionPairTableHeaderComponent extends SortedTableHeaderComponent {
             [ngClass]="data.notes"
             [data]="data"
             [leftBaseUrl]="leftBaseUrl"
-            [rightBaseUrl]="rightBaseUrl">
+            [rightBaseUrl]="rightBaseUrl"
+            [inGameCurrencySymbol]="inGameCurrencySymbol">
           </tr>
           <tr *ngIf="currRow < rowData.length">
             <th class="nav" colspan="7"
@@ -114,6 +116,7 @@ export class FusionPairTableComponent extends SortedTableComponent<FusionPair> i
   @Input() initRow = 500;
   @Input() incrRow = 500;
   @Input() lang = 'en';
+  @Input() inGameCurrencySymbol: string;
   msgs = Translations.FusionPairTableComponent;
 
   sortFuns: ((f1: FusionPair, f2: FusionPair) => number)[] = [];

--- a/src/app/compendium/components/fusion-trio-table.component.ts
+++ b/src/app/compendium/components/fusion-trio-table.component.ts
@@ -23,7 +23,7 @@ import { FusionTrio } from '../models';
         (click)="toggleShowing.emit(showIndex)">
         Show
       </th>
-      <td>{{ trio.minPrice }}</td>
+      <td>{{ inGameCurrencySymbol +( trio.minPrice | number:'1.0-0' ) }}</td>
       <td>{{ trio.demon.race }}</td>
       <td>{{ trio.demon.currLvl }}</td>
       <td><a routerLink="{{ baseUrl }}/{{ trio.demon.name }}">{{ trio.demon.name }}</a></td>
@@ -39,7 +39,7 @@ import { FusionTrio } from '../models';
         </th>
       </tr>
       <tr *ngFor="let recipe of trio.fusions">
-        <td>{{ recipe.price }}</td>
+        <td>{{ inGameCurrencySymbol + ( recipe.price | number:'1.0-0' ) }}</td>
         <td>{{ trio.demon.race }}</td>
         <td>{{ trio.demon.currLvl }}</td>
         <td><a routerLink="{{ baseUrl }}/{{ trio.demon.name }}">{{ trio.demon.name }}</a></td>
@@ -59,6 +59,7 @@ export class FusionTrioTableRowComponent {
   @Input() showing: boolean;
   @Input() showIndex: number;
   @Input() baseUrl = '../../..';
+  @Input() inGameCurrencySymbol: string;
   @Output() toggleShowing = new EventEmitter<number>();
 }
 
@@ -135,6 +136,7 @@ export class FusionTrioTableHeaderComponent extends SortedTableHeaderComponent {
           [trio]="data"
           [showing]="showing[i]"
           [showIndex]="i"
+          [inGameCurrencySymbol]="inGameCurrencySymbol"
           (toggleShowing)="toggleShowing($event)">
         </tbody>
       </table>
@@ -145,6 +147,7 @@ export class FusionTrioTableComponent extends SortedTableComponent<FusionTrio> i
   @Input() title = 'Fusion Trio Table';
   @Input() leftHeader = 'Ingredient 1';
   @Input() raceOrder: { [race: string]: number };
+  @Input() inGameCurrencySymbol: string;
   showing: boolean[] = [];
 
   protected sortFuns: ((a: FusionTrio, b: FusionTrio) => number)[] = [];

--- a/src/app/compendium/components/smt-fission-table.component.ts
+++ b/src/app/compendium/components/smt-fission-table.component.ts
@@ -17,7 +17,8 @@ export const SmtFissionTableComponentTemplate = `
     [title]="(msgs.SpecialFusionIngredients | translateComp:lang) + currentDemon"
     [baseUrl]="hasFissionFromDemons ? '../../demons' : '../..'"
     [rowData]="fusionEntries"
-    [isFusion]="true">
+    [isFusion]="true"
+    [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
   </app-fusion-entry-table>
   <app-fusion-pair-table *ngIf="fusionPairs.length || !fusionEntries.length"
     [lang]="lang"
@@ -27,7 +28,8 @@ export const SmtFissionTableComponentTemplate = `
     [leftBaseUrl]="hasFissionFromDemons ? '../../demons' : '../..'"
     [rightBaseUrl]="hasFissionFromDemons ? '../../demons' : '../..'"
     [raceOrder]="fusionChart.raceOrder"
-    [rowData]="fusionPairs">
+    [rowData]="fusionPairs"
+    [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
   </app-fusion-pair-table>
 `;
 

--- a/src/app/compendium/components/smt-fusion-table.component.ts
+++ b/src/app/compendium/components/smt-fusion-table.component.ts
@@ -16,7 +16,8 @@ export const SmtFusionTableComponentTemplate = `
     [leftBaseUrl]="'../..'"
     [rightBaseUrl]="hasFusionToPersonas ? '../../personas' : '../..'"
     [raceOrder]="fusionChart.raceOrder"
-    [rowData]="fusionPairs">
+    [rowData]="fusionPairs"
+    [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
   </app-fusion-pair-table>
 `
 

--- a/src/app/compendium/components/tri-fission-table.component.ts
+++ b/src/app/compendium/components/tri-fission-table.component.ts
@@ -15,7 +15,8 @@ import { CurrentDemonService } from '../../compendium/current-demon.service';
     <app-fusion-trio-table
       [title]="'Ingredient 1 x Ingredient 2 x Ingredient 3 = ' + currentDemon"
       [raceOrder]="chart.normalChart.raceOrder"
-      [rowData]="fissionTrios">
+      [rowData]="fissionTrios"
+      [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
     </app-fusion-trio-table>
   `
 })

--- a/src/app/compendium/components/tri-fusion-table.component.ts
+++ b/src/app/compendium/components/tri-fusion-table.component.ts
@@ -16,7 +16,8 @@ import { CurrentDemonService } from '../../compendium/current-demon.service';
       [title]="'Result = Lvl ' + compendium.getDemon(currentDemon).currLvl + ' ' + currentDemon +  ' x Ingredient 2 x Ingredient 3'"
       [raceOrder]="chart.normalChart.raceOrder"
       [leftHeader]="'Result'"
-      [rowData]="fusionTrios">
+      [rowData]="fusionTrios"
+      [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
     </app-fusion-trio-table>
   `
 })

--- a/src/app/compendium/constants.ts
+++ b/src/app/compendium/constants.ts
@@ -81,3 +81,5 @@ export const ResistanceLevels = [
 ];
 
 export const ResistOrder = getEnumOrder(ResistanceLevels);
+
+export const GameCurrency = { 'MACCA': '♄', 'YEN':'￥'};

--- a/src/app/compendium/models.ts
+++ b/src/app/compendium/models.ts
@@ -52,6 +52,7 @@ export interface Skill {
 export interface Compendium {
   allDemons: Demon[];
   allSkills: Skill[];
+  inGameCurrencySymbol: string;
   specialDemons: Demon[];
 
   getDemon(name: string): Demon;

--- a/src/app/kmt1/components/demon-entry.component.ts
+++ b/src/app/kmt1/components/demon-entry.component.ts
@@ -18,7 +18,8 @@ import { FusionDataService } from '../fusion-data.service';
         [title]="'Lvl ' + demon.lvl + ' ' + demon.race + ' ' + demon.name"
         [statHeaders]="compConfig.baseStats"
         [stats]="demon.stats"
-        [inherits]="demon.inherits">
+        [inherits]="demon.inherits"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-demon-stats>
       <app-demon-stats *ngIf="compConfig.baseAtks.length"
         [title]="'Attacks'"

--- a/src/app/kmt1/models/compendium.ts
+++ b/src/app/kmt1/models/compendium.ts
@@ -1,5 +1,6 @@
 import { Demon, Skill, CompendiumConfig } from '../models';
 import { Compendium as ICompendium, NamePair } from '../../compendium/models';
+import { GameCurrency } from '../../compendium/constants';
 
 type NumDict = { [name: string]: number };
 
@@ -148,6 +149,8 @@ export class Compendium implements ICompendium {
   get allSkills(): Skill[] {
     return this._allSkills;
   }
+
+  get inGameCurrencySymbol(){ return GameCurrency.MACCA; }
 
   get specialDemons(): Demon[] {
     return Object.keys(this.specialRecipes).map(name => this.demons[name]);

--- a/src/app/p1/components/demon-entry.component.ts
+++ b/src/app/p1/components/demon-entry.component.ts
@@ -32,12 +32,14 @@ import { FusionDataService } from '../fusion-data.service';
       <app-fusion-entry-table *ngIf="mutatesFrom.length"
         [title]="'Mutates From'"
         [baseUrl]="'..'"
-        [rowData]="mutatesFrom">
+        [rowData]="mutatesFrom"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-fusion-entry-table>
       <app-fusion-entry-table *ngIf="mutatesTo.length"
         [title]="'Mutates To'"
         [baseUrl]="'..'"
-        [rowData]="mutatesTo">
+        [rowData]="mutatesTo"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-fusion-entry-table>
       <table class="entry-table">
         <thead>

--- a/src/app/p1/models/compendium.ts
+++ b/src/app/p1/models/compendium.ts
@@ -1,5 +1,6 @@
 import { CompendiumConfig, Demon, Skill } from '../models';
 import { Compendium as ICompendium, NamePair } from '../../compendium/models';
+import { GameCurrency } from '../../compendium/constants';
 
 export class Compendium implements ICompendium {
   private demons: { [name: string]: Demon };
@@ -130,6 +131,8 @@ export class Compendium implements ICompendium {
   get allSkills(): Skill[] {
     return this._allSkills;
   }
+
+  get inGameCurrencySymbol() { return GameCurrency.YEN; }
 
   get specialDemons(): Demon[] {
     return this._allDemons.filter(d => d.fusion === 'special');

--- a/src/app/p5s/components/demon-entry.component.ts
+++ b/src/app/p5s/components/demon-entry.component.ts
@@ -20,7 +20,8 @@ import { FusionDataService } from '../fusion-data.service';
         [price]="demon.price"
         [statHeaders]="compConfig.baseStats"
         [stats]="demon.stats"
-        [inherits]="demon.inherits">
+        [inherits]="demon.inherits"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-demon-stats>
       <app-demon-resists
         [resistHeaders]="compConfig.resistElems"

--- a/src/app/p5s/components/p5s-fission-table.component.ts
+++ b/src/app/p5s/components/p5s-fission-table.component.ts
@@ -21,7 +21,7 @@ import { MultiFusionTrio } from '../models';
         <th>Names</th><th>Lvl</th>
       </tr>
       <tr *ngFor="let row of multiFissionTrios">
-        <td>{{ row.price }}</td>
+        <td>{{ compendium.inGameCurrencySymbol + (row.price | number:'1.0-0') }}</td>
         <td>
           <ul class="comma-list">
             <li *ngFor="let name of row.names1"><a routerLink="../../{{ name }}">{{ name }} </a></li>

--- a/src/app/p5s/components/p5s-fusion-table.component.ts
+++ b/src/app/p5s/components/p5s-fusion-table.component.ts
@@ -22,7 +22,7 @@ import { MultiFusionTrio } from '../models';
         <th>Names</th><th>Lvl</th>
       </tr>
       <tr *ngFor="let row of multiFusionTrios">
-        <td>{{ row.price }}</td>
+        <td>{{ compendium.inGameCurrencySymbol + (row.price | number:'1.0-0') }}</td>
         <td>{{ row.lvl0 }}</td>
         <td>
           <ul class="comma-list">

--- a/src/app/p5s/models/compendium.ts
+++ b/src/app/p5s/models/compendium.ts
@@ -1,3 +1,4 @@
+import { GameCurrency } from '../../compendium/constants';
 import { Compendium as ICompendium, NamePair, FusionEntry } from '../../compendium/models';
 import { Demon, Skill, CompendiumConfig } from '../models';
 
@@ -178,6 +179,8 @@ export class Compendium implements ICompendium {
   get allSkills(): Skill[] {
     return this._allSkills;
   }
+
+  get inGameCurrencySymbol() { return GameCurrency.YEN; }
 
   get specialDemons(): Demon[] {
     return Object.keys(this.specialRecipes).map(name => this.demons[name]);

--- a/src/app/pq2/components/demon-entry.component.ts
+++ b/src/app/pq2/components/demon-entry.component.ts
@@ -21,7 +21,8 @@ import { FusionDataService } from '../fusion-data.service';
         [statHeaders]="compConfig.baseStats"
         [stats]="demon.stats"
         [growths]="demon.growths"
-        [inherits]="compConfig.inheritElems.length ? demon.inherits : 0">
+        [inherits]="compConfig.inheritElems.length ? demon.inherits : 0"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-demon-stats>
       <app-demon-resists *ngIf="compConfig.hasDemonResists"
         [lang]="lang"

--- a/src/app/pq2/components/password-generator.component.ts
+++ b/src/app/pq2/components/password-generator.component.ts
@@ -33,7 +33,7 @@ import Translations from '../../compendium/data/translations.json';
           <th>{{ demonMsgs.Name | translateComp:lang }}</th>
         </tr>
         <tr>
-          <td>{{ price }}</td>
+          <td>{{ compendium.inGameCurrencySymbol + (price | number:'1.0-0') }}</td>
           <td>
             <select formControlName="lvl">
               <option *ngFor="let _ of range99; let i = index" [value]="i + 1">{{ i + 1 }}</option>

--- a/src/app/pq2/models/compendium.ts
+++ b/src/app/pq2/models/compendium.ts
@@ -1,4 +1,5 @@
 import { Compendium as ICompendium, NamePair } from '../../compendium/models';
+import { GameCurrency } from '../../compendium/constants';
 import { Demon, DecodedDemon, Skill, CompendiumConfig } from '../models';
 import { Toggles } from '../../compendium/models/fusion-settings';
 
@@ -262,6 +263,8 @@ export class Compendium implements ICompendium {
   get allSkills(): Skill[] {
     return this._allSkills;
   }
+
+  get inGameCurrencySymbol() { return GameCurrency.YEN; }
 
   get specialDemons(): Demon[] {
     return Object.keys(this.specialRecipes)

--- a/src/app/smt1/components/demon-entry.component.ts
+++ b/src/app/smt1/components/demon-entry.component.ts
@@ -20,7 +20,8 @@ import { FusionDataService } from '../fusion-data.service';
         [fusionHeaders]="['Drop']"
         [stats]="demon.stats"
         [price]="showPrice ? demon.price : 0"
-        [inherits]="demon.inherits">
+        [inherits]="demon.inherits"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
         <td>{{ demon.drop }}</td>
       </app-demon-stats>
       <app-demon-stats *ngIf="compConfig.baseAtks.length"

--- a/src/app/smt1/models/compendium.ts
+++ b/src/app/smt1/models/compendium.ts
@@ -1,5 +1,6 @@
 import { Demon, Skill, CompendiumConfig } from '../models';
 import { Compendium as ICompendium, NamePair } from '../../compendium/models';
+import { GameCurrency } from '../../compendium/constants';
 
 type NumDict = { [name: string]: number };
 
@@ -202,6 +203,7 @@ export class Compendium implements ICompendium {
     return this._allSkills;
   }
 
+  get inGameCurrencySymbol() {return GameCurrency.MACCA; }
   get specialDemons(): Demon[] {
     return Object.keys(this.specialRecipes).map(name => this.demons[name]);
   }

--- a/src/app/smt4f/components/demon-entry.component.ts
+++ b/src/app/smt4f/components/demon-entry.component.ts
@@ -21,7 +21,8 @@ import Translations from '../../compendium/data/translations.json';
         [price]="compConfig.appCssClasses.includes('ds1') ? 0 : demon.price"
         [statHeaders]="compConfig.baseStats"
         [stats]="demon.stats"
-        [growths]="demon.growths">
+        [growths]="demon.growths"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-demon-stats>
       <app-demon-resists
         [lang]="compConfig.lang"
@@ -77,13 +78,15 @@ import Translations from '../../compendium/data/translations.json';
         [title]="statMsgs.EvolvesFrom | translateComp:lang"
         [lang]="compConfig.lang"
         [baseUrl]="'..'"
-        [rowData]="[demon.evolvesFrom]">
+        [rowData]="[demon.evolvesFrom]"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-fusion-entry-table>
       <app-fusion-entry-table *ngIf="demon.evolvesTo"
         [title]="statMsgs.EvolvesTo | translateComp:lang"
         [lang]="compConfig.lang"
         [baseUrl]="'..'"
-        [rowData]="[demon.evolvesTo]">
+        [rowData]="[demon.evolvesTo]"
+        [inGameCurrencySymbol]="compendium.inGameCurrencySymbol">
       </app-fusion-entry-table>
       <app-smt-fusions [lang]="compConfig.lang" [excludedDlc]="demon.fusion === 'excluded'">
       </app-smt-fusions>

--- a/src/app/smt4f/models/compendium.ts
+++ b/src/app/smt4f/models/compendium.ts
@@ -2,6 +2,7 @@ import { Compendium as ICompendium, NamePair } from '../../compendium/models';
 import { Demon, Skill, CompendiumConfig } from '../models';
 import { Toggles } from '../../compendium/models/fusion-settings';
 import { toMitamaNamePairs } from '../../compendium/models/conversions';
+import { GameCurrency } from '../../compendium/constants';
 
 type NumDict = { [name: string]: number };
 type StringDict = { [name: string]: string };
@@ -286,6 +287,8 @@ export class Compendium implements ICompendium {
   get allSkills(): Skill[] {
     return this._allSkills;
   }
+
+  get inGameCurrencySymbol() { return GameCurrency.MACCA; }
 
   get specialDemons(): Demon[] {
     return Object.keys(this.specialRecipes).map(name => this.demons[name]);


### PR DESCRIPTION
Added an inGameCurrencySymbol (macca or yen) to the compendium and set it for all the games. 

Presents all prices as in locale format with the correct in-game Currency Symbol.